### PR TITLE
Analyse Only Feature (MM v3.5)

### DIFF
--- a/anki/plugins/morphman3/morph/config.py
+++ b/anki/plugins/morphman3/morph/config.py
@@ -33,7 +33,7 @@ default = {
     # only these can have model overrides
     'enabled':False,    # whether to analyze notes of a given model, modify their fields, and manipulate due time by Morph Man Index
     'analyze':False,    # whether to analyze notes of a given model (no modification)
-	'set due based on mmi':True,    # whether to modify card Due times based on MorphManIndex. does nothing if relevant notes aren't enabled
+    'set due based on mmi':True,    # whether to modify card Due times based on MorphManIndex. does nothing if relevant notes aren't enabled
     'ignore maturity':False,        # if True, pretends card maturity is always zero
         # field names to store various information
     'k+N':u'k+N',       # stores how many unknowns

--- a/anki/plugins/morphman3/morph/config.py
+++ b/anki/plugins/morphman3/morph/config.py
@@ -32,7 +32,8 @@ default = {
 
     # only these can have model overrides
     'enabled':False,    # whether to analyze notes of a given model, modify their fields, and manipulate due time by Morph Man Index
-    'set due based on mmi':True,    # whether to modify card Due times based on MorphManIndex. does nothing if relevant notes aren't enabled
+    'analyze':False,    # whether to analyze notes of a given model (no modification)
+	'set due based on mmi':True,    # whether to modify card Due times based on MorphManIndex. does nothing if relevant notes aren't enabled
     'ignore maturity':False,        # if True, pretends card maturity is always zero
         # field names to store various information
     'k+N':u'k+N',       # stores how many unknowns

--- a/anki/plugins/morphman3/morph/main.py
+++ b/anki/plugins/morphman3/morph/main.py
@@ -38,7 +38,7 @@ def mkAllDb( allDb=None ):
     for i,( nid, mid, flds, guid, tags ) in enumerate( db.execute( 'select id, mid, flds, guid, tags from notes' ) ):
         if i % 500 == 0:    mw.progress.update( value=i )
         C = partial( cfg, mid, None )
-        if not C('enabled'): continue
+        if isAnalysisEnabled(C): continue
         
         mats = [ ( 0.5 if ivl == 0 and ctype == 1 else ivl ) for ivl, ctype in db.execute( 'select ivl, type from cards where nid = :nid', nid=nid ) ]
         if C('ignore maturity'):
@@ -87,6 +87,9 @@ def mkAllDb( allDb=None ):
         printf( 'Processed all %d notes + saved all.db in %f sec' % ( N_notes, time.time() - t_0 ) )
     mw.progress.finish()
     return allDb
+
+def isAnalysisEnabled(noteConfig):
+	return ( not noteConfig('enabled') and not noteConfig('analyze'))
 
 def filterDbByMat( db, mat ):
     '''Assumes safe to use cached locDb'''

--- a/anki/plugins/morphman3/morph/main.py
+++ b/anki/plugins/morphman3/morph/main.py
@@ -89,7 +89,7 @@ def mkAllDb( allDb=None ):
     return allDb
 
 def isAnalysisEnabled(noteConfig):
-	return ( not noteConfig('enabled') and not noteConfig('analyze'))
+    return ( not noteConfig('enabled') and not noteConfig('analyze'))
 
 def filterDbByMat( db, mat ):
     '''Assumes safe to use cached locDb'''


### PR DESCRIPTION
Implemented the 'analyze morphemes only' feature used by other members of the koohii forums.
This lets Morphman extract morphemes from a note type into the all/seen/mature/etc database, but will not adjust the scheduling for those cards.

Example config.py line: 'GenkiSentence': { 'analyze':True, 'morph_fields': [u'Expression']}
